### PR TITLE
Update mobile speedtracker

### DIFF
--- a/_profiles/vega.html
+++ b/_profiles/vega.html
@@ -8,7 +8,7 @@ name: "20 Minutes mobile"
 #
 # The default profile will be the one shown when accessing the root URL of your
 # SpeedTracker site.
-# 
+#
 default: false
 
 #
@@ -24,8 +24,9 @@ interval: 12
 parameters:
   connectivity: "Cable"
   location: "ec2-eu-west-1:Chrome"
+  mobile: 1
   runs: 1
-  url: "http://m.20minutes.fr"
+  url: "http://www.20minutes.fr"
 
 #
 # Performance budgets are defined with a metric id, a max/min allowed value


### PR DESCRIPTION
Update mobile config to test `www.20minutes.fr` instead of `m.20minutes.fr` from a mobile device